### PR TITLE
Handle nan version ids

### DIFF
--- a/3-Upload_Classification.ipynb
+++ b/3-Upload_Classification.ipynb
@@ -27,12 +27,7 @@
     "from rasterio.warp import transform_bounds"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:09.814230Z",
-     "start_time": "2022-09-22T01:31:09.286954Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -46,49 +41,39 @@
    "execution_count": null,
    "source": [
     "#Name of person who reviewed the classification. Leave as \"None\" if classification has not been reviewed\n",
-    "reviewer_name = 'Matthew Bonnema' \n",
+    "reviewer_name = '' \n",
     "\n",
     "#Usually 'Mannual classification' or 'Review'\n",
-    "calc_type = 'Review' \n",
+    "calc_type = '' \n",
     "\n",
     "#Either 'Intermediate' or 'Final' if review is classification passed review with no changes\n",
-    "processing_level = 'Final' \n",
+    "processing_level = '' \n",
     "\n",
     "#Processing notes. e.g. 'Supervised classification using \n",
-    "# SCP mannual edits using Serval informed by Pekel water mask'\n",
-    "notes = 'Update to classification upload method'\n",
+    "# SCP manual edits using Serval informed by Pekel water mask'\n",
+    "notes = ''\n",
     "\n",
     "# Who made the classification - else specify \"review\"\n",
-    "editor_name = 'Alexander Handwerger' \n",
+    "editor_name = '' \n",
     "\n",
     "fields = [editor_name, notes, processing_level, calc_type, reviewer_name]\n",
     "if any([not f for f in fields]):\n",
     "    raise ValueError"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T20:09:57.708047Z",
-     "start_time": "2022-09-22T20:09:57.395891Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "source": [
     "#Only specify one. Leave the other as ''. If more than one planet image for given chip, PLANET_ID must be specified \n",
-    "PLANET_ID = '20211019_180019_07_2453'\n",
+    "PLANET_ID = ''\n",
     "SITE_NAME = ''\n",
     "assert((len(PLANET_ID) == 0) ^ (len(SITE_NAME) == 0))"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:09.818240Z",
-     "start_time": "2022-09-22T01:31:09.815850Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -108,12 +93,7 @@
     "s3_client = session.client('s3')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.231689Z",
-     "start_time": "2022-09-22T01:31:09.820068Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -131,12 +111,7 @@
     "imagecalcTable = gpd.read_file(s3.Object(bucket_name,'image_calc.geojson').get()['Body'])"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.772975Z",
-     "start_time": "2022-09-22T01:31:10.237068Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -147,12 +122,7 @@
     "df_image2site = temp.set_index('image_name')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.779150Z",
-     "start_time": "2022-09-22T01:31:10.774875Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -172,37 +142,7 @@
     "(SITE_NAME, PLANET_ID)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.790221Z",
-     "start_time": "2022-09-22T01:31:10.780824Z"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "# This cell will show the number of planet images found for a given chip. If more than one, ensure the printed Planet\n",
-    "# ID matches the planet image used to generate the classification\n",
-    "if not PLANET_ID:\n",
-    "    values = PLANET_ID = df_site2image.loc[SITE_NAME].tolist()\n",
-    "    PLANET_ID = values[0]\n",
-    "    print(f'There was {len(values)} planet images for this chip')\n",
-    "else:\n",
-    "    values = df_image2site.loc[PLANET_ID].tolist()\n",
-    "    SITE_NAME = values[0]\n",
-    "    print(f'There were {len(values)} chips for this planet_image')\n",
-    "\n",
-    "(SITE_NAME, PLANET_ID)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.790221Z",
-     "start_time": "2022-09-22T01:31:10.780824Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -213,12 +153,7 @@
     "geometry = planet_image.geometry.iloc[0]"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.798263Z",
-     "start_time": "2022-09-22T01:31:10.793207Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -248,12 +183,7 @@
     "        print('Older versions found, but could not identify version number')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:11.256536Z",
-     "start_time": "2022-09-22T01:31:11.249525Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -275,12 +205,7 @@
     "imagecalc_metadata_prev"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:12.038071Z",
-     "start_time": "2022-09-22T01:31:12.033806Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -299,12 +224,7 @@
     "    "
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:30:56.911962Z",
-     "start_time": "2022-09-22T01:30:56.898195Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -332,12 +252,7 @@
     "assert((uploadDir / classified_image_filename).exists())"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.713825Z",
-     "start_time": "2022-09-20T20:42:57.710727Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -366,12 +281,7 @@
     "print(f'Fraction of water is {water_frac: 1.3f}')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.772857Z",
-     "start_time": "2022-09-20T20:42:57.715344Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -386,12 +296,7 @@
     "water_stratum"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.778447Z",
-     "start_time": "2022-09-20T20:42:57.774448Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -411,12 +316,7 @@
     "    print(f'Area with {pw*100}% water is in strata {ind}')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.783497Z",
-     "start_time": "2022-09-20T20:42:57.779652Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -430,7 +330,7 @@
     "\n",
     "+ 0 = no water\n",
     "+ 1 = water\n",
-    "+ 7 = will not classify\n",
+    "+ 10 = will not classify\n",
     "+ 255 = no data"
    ],
    "metadata": {}
@@ -454,17 +354,13 @@
     "    assert(nodata == 255)\n",
     "\n",
     "    vals = set(np.unique(water_mask))\n",
-    "    assert(vals.issubset(set([0, 1, 7, 255])))\n",
+    "    print(f'Vals: {vals}')\n",
+    "    assert(vals.issubset(set([0, 1, 10, 255])))\n",
     "\n",
     "    assert(water_mask.dtype == 'uint8')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.950580Z",
-     "start_time": "2022-09-20T20:42:57.785254Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -477,7 +373,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "if False:\n",
+    "if True:\n",
     "    classified_image_filename_old = classified_image_filename\n",
     "    classified_image_filename = classified_image_filename.replace('.tif', '_formatted.tif')\n",
     "    \n",
@@ -488,12 +384,7 @@
     "        ds.write(water_mask.astype(np.uint8), 1)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.955317Z",
-     "start_time": "2022-09-20T20:42:57.952479Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -517,12 +408,7 @@
     "classified_geometry"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.965278Z",
-     "start_time": "2022-09-20T20:42:57.956889Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -544,12 +430,7 @@
     "filePaths"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.970401Z",
-     "start_time": "2022-09-20T20:42:57.966814Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -571,12 +452,7 @@
     "metaData"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.976915Z",
-     "start_time": "2022-09-20T20:42:57.972149Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -595,31 +471,12 @@
     "addImageCalc(filePaths,metaData,session)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.980625Z",
-     "start_time": "2022-09-20T20:42:57.978558Z"
-    }
-   }
+   "metadata": {}
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "openscapes",
-   "language": "python",
-   "name": "openscapes"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/3-Upload_Classification.ipynb
+++ b/3-Upload_Classification.ipynb
@@ -2,22 +2,15 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Example of Staging Upload to ImageCalc Table\n",
     "This notebook goes through an example of uploading a classified planet image, a logfile, and training data to the DSWx calval database. Data files and metadata are uploading to a staging bucket. Then, the database manager will commit these uploads to the database"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:09.814230Z",
-     "start_time": "2022-09-22T01:31:09.286954Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "import geopandas as gpd\n",
     "import pandas as pd\n",
@@ -32,25 +25,25 @@
     "from shapely.geometry import box\n",
     "from rasterio.crs import CRS\n",
     "from rasterio.warp import transform_bounds"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:09.814230Z",
+     "start_time": "2022-09-22T01:31:09.286954Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "YOU NEED TO FILL THESE OUT!"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T20:09:57.708047Z",
-     "start_time": "2022-09-22T20:09:57.395891Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "#Name of person who reviewed the classification. Leave as \"None\" if classification has not been reviewed\n",
     "reviewer_name = 'Matthew Bonnema' \n",
@@ -71,99 +64,99 @@
     "fields = [editor_name, notes, processing_level, calc_type, reviewer_name]\n",
     "if any([not f for f in fields]):\n",
     "    raise ValueError"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T20:09:57.708047Z",
+     "start_time": "2022-09-22T20:09:57.395891Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:09.818240Z",
-     "start_time": "2022-09-22T01:31:09.815850Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "#Only specify one. Leave the other as ''. If more than one planet image for given chip, PLANET_ID must be specified \n",
     "PLANET_ID = '20211019_180019_07_2453'\n",
     "SITE_NAME = ''\n",
     "assert((len(PLANET_ID) == 0) ^ (len(SITE_NAME) == 0))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:09.818240Z",
+     "start_time": "2022-09-22T01:31:09.815850Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### AWS Credentials\n",
     "In order to download imagery from the private bucket, JPL RSA access and OPERA Calval AWS credenitals are needed"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.231689Z",
-     "start_time": "2022-09-22T01:31:09.820068Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "bucket_name = 'opera-calval-database-dswx'\n",
     "session = boto3.session.Session(profile_name='saml-pub')\n",
     "s3 = session.resource('s3')\n",
     "s3_client = session.client('s3')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:10.231689Z",
+     "start_time": "2022-09-22T01:31:09.820068Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Read Image metadata table\n",
     "To get the geometry metadata for the classified image. Make sure we connect `site_name` and `planet_id` correctly."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "imageTable = gpd.read_file(s3.Object(bucket_name,'image.geojson').get()['Body'])\n",
+    "imagecalcTable = gpd.read_file(s3.Object(bucket_name,'image_calc.geojson').get()['Body'])"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-22T01:31:10.772975Z",
      "start_time": "2022-09-22T01:31:10.237068Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "imageTable = gpd.read_file(s3.Object(bucket_name,'image.geojson').get()['Body'])\n",
-    "imagecalcTable = gpd.read_file(s3.Object(bucket_name,'image_calc.geojson').get()['Body'])"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "temp = imageTable[['image_name', 'site_name']]\n",
+    "df_site2image = temp.set_index('site_name')\n",
+    "df_image2site = temp.set_index('image_name')"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-22T01:31:10.779150Z",
      "start_time": "2022-09-22T01:31:10.774875Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "temp = imageTable[['image_name', 'site_name']]\n",
-    "df_site2image = temp.set_index('site_name')\n",
-    "df_image2site = temp.set_index('image_name')"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:10.790221Z",
-     "start_time": "2022-09-22T01:31:10.780824Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "# This cell will show the number of planet images found for a given chip. If more than one, ensure the printed Planet\n",
     "# ID matches the planet image used to generate the classification\n",
@@ -177,41 +170,66 @@
     "    print(f'There were {len(values)} chips for this planet_image')\n",
     "\n",
     "(SITE_NAME, PLANET_ID)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:10.790221Z",
+     "start_time": "2022-09-22T01:31:10.780824Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "# This cell will show the number of planet images found for a given chip. If more than one, ensure the printed Planet\n",
+    "# ID matches the planet image used to generate the classification\n",
+    "if not PLANET_ID:\n",
+    "    values = PLANET_ID = df_site2image.loc[SITE_NAME].tolist()\n",
+    "    PLANET_ID = values[0]\n",
+    "    print(f'There was {len(values)} planet images for this chip')\n",
+    "else:\n",
+    "    values = df_image2site.loc[PLANET_ID].tolist()\n",
+    "    SITE_NAME = values[0]\n",
+    "    print(f'There were {len(values)} chips for this planet_image')\n",
+    "\n",
+    "(SITE_NAME, PLANET_ID)"
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:10.790221Z",
+     "start_time": "2022-09-22T01:31:10.780824Z"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "search = imageTable[imageTable.image_name == PLANET_ID]\n",
+    "planet_image = search.iloc[[0]]\n",
+    "geometry = planet_image.geometry.iloc[0]"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-22T01:31:10.798263Z",
      "start_time": "2022-09-22T01:31:10.793207Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "search = imageTable[imageTable.image_name == PLANET_ID]\n",
-    "planet_image = search.iloc[[0]]\n",
-    "geometry = planet_image.geometry.iloc[0]"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Versioning simply increments to maximum version. If you downloaded imagery. Should have a metadata file from previous run."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:11.256536Z",
-     "start_time": "2022-09-22T01:31:11.249525Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "# This cell assigns a version number to the classification. If this is the first classification of a given planet\n",
     "# image, the assigned version should be 0. Otherwise, it will increment on the latest version found in the database\n",
@@ -228,25 +246,25 @@
     "    except:\n",
     "        previous_name = None\n",
     "        print('Older versions found, but could not identify version number')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:11.256536Z",
+     "start_time": "2022-09-22T01:31:11.249525Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Check Previous Metadata or write new"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:31:12.038071Z",
-     "start_time": "2022-09-22T01:31:12.033806Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "imagecalc_metadata_path = Path(f'planet_images_cropped/{PLANET_ID}/metadata_{PLANET_ID}_v{prev_version}.geojson')\n",
     "imagecalc_metadata_prev = {}\n",
@@ -255,18 +273,18 @@
     "    imagecalc_metadata_prev = df_metadata.to_dict('records')[0]\n",
     "    \n",
     "imagecalc_metadata_prev"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:31:12.038071Z",
+     "start_time": "2022-09-22T01:31:12.033806Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-22T01:30:56.911962Z",
-     "start_time": "2022-09-22T01:30:56.898195Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "if imagecalc_metadata_path.exists():\n",
     "    editor_name =  imagecalc_metadata_prev['calculated_by']\n",
@@ -279,25 +297,25 @@
     "    if not editor_name:\n",
     "        raise ValueError('Update editor name in previous cell')\n",
     "    "
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-22T01:30:56.911962Z",
+     "start_time": "2022-09-22T01:30:56.898195Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Read Image"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.713825Z",
-     "start_time": "2022-09-20T20:42:57.710727Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "#Local directory where classification file(s) are located\n",
     "uploadDir = Path(f'planet_images_cropped/{PLANET_ID}').absolute()\n",
@@ -312,30 +330,30 @@
     "#additional_filename = 'additional_file.txt' \n",
     "\n",
     "assert((uploadDir / classified_image_filename).exists())"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.713825Z",
+     "start_time": "2022-09-20T20:42:57.710727Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "# Compute Stratum"
+   ],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-19T23:42:58.710258Z",
      "start_time": "2022-09-19T23:42:58.708000Z"
     }
-   },
-   "source": [
-    "# Compute Stratum"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.772857Z",
-     "start_time": "2022-09-20T20:42:57.715344Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "with rasterio.open(uploadDir / classified_image_filename) as ds:\n",
     "    water_mask = ds.read(1)\n",
@@ -346,18 +364,18 @@
     "data_mask = (water_mask != nodata)\n",
     "water_frac = (water_mask == 1).sum() / data_mask.sum()\n",
     "print(f'Fraction of water is {water_frac: 1.3f}')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.772857Z",
+     "start_time": "2022-09-20T20:42:57.715344Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.778447Z",
-     "start_time": "2022-09-20T20:42:57.774448Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -366,18 +384,18 @@
     "    return np.digitize(water_frac, bins, right=True)\n",
     "water_stratum = stratify(water_frac)\n",
     "water_stratum"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.778447Z",
+     "start_time": "2022-09-20T20:42:57.774448Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.783497Z",
-     "start_time": "2022-09-20T20:42:57.779652Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "# Example\n",
     "print('Strata for percent water x')\n",
@@ -391,11 +409,17 @@
     "for pw in [0, 0.0001, 0.0008, 0.001, 0.01, .03]:\n",
     "    ind = stratify(pw)\n",
     "    print(f'Area with {pw*100}% water is in strata {ind}')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.783497Z",
+     "start_time": "2022-09-20T20:42:57.779652Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Datatypes\n",
     "\n",
@@ -408,25 +432,19 @@
     "+ 1 = water\n",
     "+ 7 = will not classify\n",
     "+ 255 = no data"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Can make this conditional flow `False` if you are annoyed by this additional check."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.950580Z",
-     "start_time": "2022-09-20T20:42:57.785254Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "if True:\n",
     "    with rasterio.open(uploadDir / classified_image_filename) as ds:\n",
@@ -439,25 +457,25 @@
     "    assert(vals.issubset(set([0, 1, 7, 255])))\n",
     "\n",
     "    assert(water_mask.dtype == 'uint8')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.950580Z",
+     "start_time": "2022-09-20T20:42:57.785254Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Should you want to either update nodata or dtype, change to True. Will update your data to append a `_formatted` suffix to the file name."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.955317Z",
-     "start_time": "2022-09-20T20:42:57.952479Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "if False:\n",
     "    classified_image_filename_old = classified_image_filename\n",
@@ -468,25 +486,25 @@
     "    p['dtype'] = np.uint8\n",
     "    with rasterio.open(uploadDir / classified_image_filename, 'w', **p) as ds:\n",
     "        ds.write(water_mask.astype(np.uint8), 1)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.955317Z",
+     "start_time": "2022-09-20T20:42:57.952479Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Get the polygon in 4326"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.965278Z",
-     "start_time": "2022-09-20T20:42:57.956889Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "# Classified Image read and geometry\n",
     "\n",
@@ -497,26 +515,26 @@
     "bounds_4326 = transform_bounds(crs_utm, CRS.from_epsg(4326), *bounds)\n",
     "classified_geometry = box(*bounds_4326)\n",
     "classified_geometry"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.965278Z",
+     "start_time": "2022-09-20T20:42:57.956889Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Enter the required file locations and metadata fields\n",
     "To upload the classified image, we need to specify its location on the local computer (and the location of auxilary files). We also need to fill in some metadata fields. Both file paths and metadata are specified as dictionaries"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.970401Z",
-     "start_time": "2022-09-20T20:42:57.966814Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "filePaths = {\n",
     "    'image_calc' : str(uploadDir  / classified_image_filename),\n",
@@ -524,18 +542,18 @@
     "    #additional_file: additional_file_name #uncomment this line if uploading additional file\n",
     "}\n",
     "filePaths"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.970401Z",
+     "start_time": "2022-09-20T20:42:57.966814Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:42:57.976915Z",
-     "start_time": "2022-09-20T20:42:57.972149Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "metaData = {\n",
     "    'image_name':planet_image.image_name.iloc[0], #str\n",
@@ -551,38 +569,38 @@
     "    'geometry': classified_geometry, #shapely geometry\n",
     "}\n",
     "metaData"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:42:57.976915Z",
+     "start_time": "2022-09-20T20:42:57.972149Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Stage the image\n",
     "We use a pre-defined function to upload files and metadata to the staging area. This function takes the file paths and metadata dictionaries, as well as the AWS session object as inputs\n",
     "\n",
     "    "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "addImageCalc(filePaths,metaData,session)"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:42:57.980625Z",
      "start_time": "2022-09-20T20:42:57.978558Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "addImageCalc(filePaths,metaData,session)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   }
   }
  ],
  "metadata": {

--- a/4-Download_Classification.ipynb
+++ b/4-Download_Classification.ipynb
@@ -213,7 +213,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "#This cell selects the classificaiton with the highest 'version' value (i.e. the most recent version)\n",
+    "#This cell selects the classification with the highest 'version' value (i.e. the most recent version)\n",
     "#If the version is listed as 'NaN'. then the classification with the most recent 'upload_date' instead will be passed\n",
     "try:\n",
     "    search_iter = search[search.version==search['version'].max()]\n",

--- a/4-Download_Classification.ipynb
+++ b/4-Download_Classification.ipynb
@@ -18,12 +18,7 @@
     "from pathlib import Path"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.233003Z",
-     "start_time": "2022-09-20T20:27:02.371154Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -37,17 +32,12 @@
    "execution_count": null,
    "source": [
     "#Only specify one. Leave the other as ''. If more than one planet image for given chip, PLANET_ID must be specified\n",
-    "PLANET_ID = '20211003_161639_91_241d'\n",
+    "PLANET_ID = '20210924_082025_48_2424'\n",
     "SITE_NAME = ''\n",
     "assert((len(PLANET_ID) == 0) ^ (len(SITE_NAME) == 0))"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.236867Z",
-     "start_time": "2022-09-20T20:27:04.234739Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -67,12 +57,7 @@
     "s3_client = session.client('s3')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.349613Z",
-     "start_time": "2022-09-20T20:27:04.238943Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -81,12 +66,7 @@
     "bucket_name = 'opera-calval-database-dswx'"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.353171Z",
-     "start_time": "2022-09-20T20:27:04.351260Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -97,12 +77,7 @@
     "imageTable = gpd.read_file(image_table_data)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.983904Z",
-     "start_time": "2022-09-20T20:27:04.514237Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -113,12 +88,7 @@
     "image_calcs = gpd.read_file(image_table_data)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:05.081530Z",
-     "start_time": "2022-09-20T20:27:04.985960Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -141,12 +111,7 @@
     "(SITE_NAME, PLANET_ID)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:05.103666Z",
-     "start_time": "2022-09-20T20:27:05.089611Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -157,12 +122,7 @@
     "download_dir.mkdir(exist_ok=True, parents=True)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:05.540390Z",
-     "start_time": "2022-09-20T20:27:05.537976Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -179,12 +139,7 @@
     "                                           str(download_dir / filename))"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:06.965349Z",
-     "start_time": "2022-09-20T20:27:06.962412Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -202,12 +157,7 @@
     "search.head(20)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:08.565727Z",
-     "start_time": "2022-09-20T20:27:08.546193Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -224,12 +174,7 @@
     "imagecalc_row.head()"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:09.990698Z",
-     "start_time": "2022-09-20T20:27:09.962519Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -249,12 +194,7 @@
     "imagecalc_row.to_file(download_dir / f'metadata_{PLANET_ID}_v{version}.geojson', driver='GeoJSON')"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:13.562468Z",
-     "start_time": "2022-09-20T20:27:13.546154Z"
-    }
-   }
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -270,31 +210,28 @@
     "downloadImage_calc(imagecalc_row,download_dir)"
    ],
    "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T17:25:49.802631Z",
-     "start_time": "2022-09-20T17:25:48.912123Z"
-    }
-   }
+   "metadata": {}
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
+   "name": "python",
+   "version": "3.10.5",
+   "mimetype": "text/x-python",
    "codemirror_mode": {
     "name": "ipython",
     "version": 3
    },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "nbconvert_exporter": "python",
+   "file_extension": ".py"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.10.5 64-bit ('dswx_calval': conda)"
+  },
+  "interpreter": {
+   "hash": "b27355d824205a6094e643e0a56e21b52f8e5443282470402e946fba6e4828a5"
   }
  },
  "nbformat": 4,

--- a/4-Download_Classification.ipynb
+++ b/4-Download_Classification.ipynb
@@ -2,134 +2,127 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Download Classification and Manually Edit"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.233003Z",
-     "start_time": "2022-09-20T20:27:02.371154Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "import geopandas as gpd\n",
     "import boto3\n",
     "import os\n",
     "from tools.addImageCalc import addImageCalc\n",
     "from pathlib import Path"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:27:04.233003Z",
+     "start_time": "2022-09-20T20:27:02.371154Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### User defines the validation site and the directory where files will be downloaded"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:04.236867Z",
-     "start_time": "2022-09-20T20:27:04.234739Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "#Only specify one. Leave the other as ''. If more than one planet image for given chip, PLANET_ID must be specified\n",
     "PLANET_ID = '20211003_161639_91_241d'\n",
     "SITE_NAME = ''\n",
     "assert((len(PLANET_ID) == 0) ^ (len(SITE_NAME) == 0))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:27:04.236867Z",
+     "start_time": "2022-09-20T20:27:04.234739Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Open AWS session and read image and image_calc tables"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "os.environ[\"AWS_NO_SIGN_REQUEST\"] = \"YES\"\n",
+    "\n",
+    "session = boto3.session.Session(profile_name='saml-pub')\n",
+    "s3 = session.resource('s3')\n",
+    "s3_client = session.client('s3')"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:04.349613Z",
      "start_time": "2022-09-20T20:27:04.238943Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "os.environ[\"AWS_NO_SIGN_REQUEST\"] = \"YES\"\n",
-    "\n",
-    "session = boto3.session.Session()\n",
-    "s3 = session.resource('s3')\n",
-    "s3_client = session.client('s3')"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "bucket_name = 'opera-calval-database-dswx'"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:04.353171Z",
      "start_time": "2022-09-20T20:27:04.351260Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "bucket_name = 'opera-calval-database-dswx'"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "obj = s3.Object(bucket_name,'image.geojson')\n",
+    "image_table_data = obj.get()['Body']\n",
+    "imageTable = gpd.read_file(image_table_data)"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:04.983904Z",
      "start_time": "2022-09-20T20:27:04.514237Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "obj = s3.Object(bucket_name,'image.geojson')\n",
-    "image_table_data = obj.get()['Body']\n",
-    "imageTable = gpd.read_file(image_table_data)"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "obj = s3.Object(bucket_name,'image_calc.geojson')\n",
+    "image_table_data = obj.get()['Body']\n",
+    "image_calcs = gpd.read_file(image_table_data)"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:05.081530Z",
      "start_time": "2022-09-20T20:27:04.985960Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "obj = s3.Object(bucket_name,'image_calc.geojson')\n",
-    "image_table_data = obj.get()['Body']\n",
-    "image_calcs = gpd.read_file(image_table_data)"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:05.103666Z",
-     "start_time": "2022-09-20T20:27:05.089611Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "# This cell will show the number of planet images found for a given chip. If more than one, ensure the printed Planet\n",
     "# ID matches the planet image used to generate the classification\n",
@@ -146,34 +139,34 @@
     "    print(f'There were {len(values)} chips for this planet_image')\n",
     "\n",
     "(SITE_NAME, PLANET_ID)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:27:05.103666Z",
+     "start_time": "2022-09-20T20:27:05.089611Z"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "#Local directory where classification file(s) are located\n",
+    "download_dir = Path(f'planet_images_cropped/{PLANET_ID}').absolute()\n",
+    "download_dir.mkdir(exist_ok=True, parents=True)"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:05.540390Z",
      "start_time": "2022-09-20T20:27:05.537976Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "#Local directory where classification file(s) are located\n",
-    "download_dir = Path(f'planet_images_cropped/{PLANET_ID}').absolute()\n",
-    "download_dir.mkdir(exist_ok=True, parents=True)"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2022-09-20T20:27:06.965349Z",
-     "start_time": "2022-09-20T20:27:06.962412Z"
-    }
-   },
-   "outputs": [],
    "source": [
     "def downloadImage_calc(row,download_dir):\n",
     "    bucket = row.bucket.iloc[0]\n",
@@ -184,93 +177,105 @@
     "        response = s3_client.download_file(bucket,\n",
     "                                           key,\n",
     "                                           str(download_dir / filename))"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-09-20T20:27:06.965349Z",
+     "start_time": "2022-09-20T20:27:06.962412Z"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Search for specific image and classified image for the defined validation site"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "#This cell shows all classifications of specified planet image\n",
+    "search = image_calcs[image_calcs.image_name == PLANET_ID]\n",
+    "search.head(20)"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:08.565727Z",
      "start_time": "2022-09-20T20:27:08.546193Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "#This cell shows all classifications of specified planet image\n",
-    "search = image_calcs[image_calcs.image_name == PLANET_ID]\n",
-    "search.head(20)"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "#This cell selects the classificaiton with the highest 'version' value (i.e. the most recent version)\n",
+    "#If the version is listed as 'NaN'. then the classification with the most recent 'upload_date' instead will be passed\n",
+    "try:\n",
+    "    search_iter = search[search.version==search['version'].max()]\n",
+    "    search_iter = search_iter.iloc[[0]]\n",
+    "except IndexError:\n",
+    "    search_iter = search[search.upload_date.values==search.upload_date.values.max()]\n",
+    "imagecalc_row = search_iter\n",
+    "imagecalc_row.head()"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:09.990698Z",
      "start_time": "2022-09-20T20:27:09.962519Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "#This cell selects the classificaiton with the highest 'version' value (i.e. the most recent version)\n",
-    "search = search[search.version==search['version'].max()]\n",
-    "imagecalc_row = search.iloc[[0]]\n",
-    "imagecalc_row.head()"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Download Metadata \n",
     "\n",
     "Label it by version"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "image_calc_name = imagecalc_row.image_calc_name.iloc[0]\n",
+    "version = imagecalc_row.version.iloc[0]\n",
+    "imagecalc_row.to_file(download_dir / f'metadata_{PLANET_ID}_v{version}.geojson', driver='GeoJSON')"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T20:27:13.562468Z",
      "start_time": "2022-09-20T20:27:13.546154Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "image_calc_name = imagecalc_row.image_calc_name.iloc[0]\n",
-    "version = imagecalc_row.version.iloc[0]\n",
-    "imagecalc_row.to_file(download_dir / f'metadata_{PLANET_ID}_v{version}.geojson', driver='GeoJSON')"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Download classified image to the specified directory"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "source": [
+    "downloadImage_calc(imagecalc_row,download_dir)"
+   ],
+   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-09-20T17:25:49.802631Z",
      "start_time": "2022-09-20T17:25:48.912123Z"
     }
-   },
-   "outputs": [],
-   "source": [
-    "downloadImage_calc(imagecalc_row,download_dir)"
-   ]
+   }
   }
  ],
  "metadata": {


### PR DESCRIPTION
Minor fixes for 2 bugs:
1. To circumvent credential errors query session as so: `session = boto3.session.Session(profile_name='saml-pub')`
2. If a version is listed as 'NaN', query classification based off of most recent 'upload_date'