### PR TITLE
Carry over mask

### DIFF
--- a/2-Crop_Imagery.ipynb
+++ b/2-Crop_Imagery.ipynb
@@ -265,6 +265,9 @@
    "outputs": [],
    "source": [
     "if True:\n",
+    "    with rasterio.open(cropped_dir / f'cropped_{PLANET_ID}.tif') as ds:\n",
+    "        mask = ~(ds.read_masks(1).astype(bool))\n",
+    "        \n",
     "    hand_edited = np.zeros(out_image[0,...].shape, dtype='uint8')\n",
     "    p_he = out_meta.copy()\n",
     "    p_he['count'] = 1\n",
@@ -295,8 +298,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When making the hand edit raster, make sure the nodata from the cropped planet image is carried over to the new raster.