### PR TITLE
Demonstrate manual crop for Planet Imagery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,8 @@ tests/notebooks/
 # Add new notebooks
 *.ipynb
 !1-Download_Planet_Imagery.ipynb
-!2-Crop_Imagery.ipynb
+!2a-Crop_Imagery.ipynb
+!2b-Crop_Imagery_Manual.ipynb
 !3-Upload_Classification.ipynb
 !4-Download_Classification.ipynb
 !5-Visualize_Status_of_Validation_Datasets.ipynb

--- a/2a-Crop_Imagery.ipynb
+++ b/2a-Crop_Imagery.ipynb
@@ -44,7 +44,7 @@
    "outputs": [],
    "source": [
     "PLANET_ID = ''\n",
-    "SITE_NAME = '2_26'\n",
+    "SITE_NAME = ''\n",
     "\n",
     "# ^ is exclusive or; makes sure you only specified one\n",
     "assert((len(PLANET_ID) == 0) ^ (len(SITE_NAME) == 0))"

--- a/2b-Crop_Imagery_Manual.ipynb
+++ b/2b-Crop_Imagery_Manual.ipynb
@@ -1,0 +1,317 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Crop the Planet Image\n",
+    "\n",
+    "This notebook shows how to crop the planet image by specifying the upper left corner of where you want to crop and the square size. In case the pre-determined chip area is offset from planet image and needs to be shifted around manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import os\n",
+    "import rasterio\n",
+    "import rasterio.mask\n",
+    "from pathlib import Path\n",
+    "from rasterio.plot import show\n",
+    "from rasterio.crs import CRS\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import shutil\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parameters\n",
+    "\n",
+    "Specify *exactly* one. The `site_name` or the `planet_id`. The former is given to the chip by the validation team. Because we are not selecting multiple planet scenes per chip and not selecting planet images that cover multiple chips (they are sufficiently spaced apart), this should be a 1 to 1 mapping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PLANET_ID = ''\n",
+    "SITE_NAME = '4_19'\n",
+    "\n",
+    "# ^ is exclusive or; makes sure you only specified one\n",
+    "assert((len(PLANET_ID) == 0) ^ (len(SITE_NAME) == 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ[\"AWS_NO_SIGN_REQUEST\"] = \"YES\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get Image Database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_images = gpd.read_file('s3://opera-calval-database-dswx/image.geojson')\n",
+    "df_images.dropna(inplace=True)\n",
+    "df_images.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_site = gpd.read_file('s3://opera-calval-database-dswx/site.geojson')\n",
+    "df_site.dropna(inplace=True)\n",
+    "df_site.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols_to_merge = [col for col in df_images.columns if col != 'geometry']\n",
+    "df_temp = df_images[cols_to_merge]\n",
+    "df_chips = pd.merge(df_site, df_temp , on='site_name', how='left')\n",
+    "df_chips.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_chips.buffer(2).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temp = df_chips[['image_name', 'site_name']]\n",
+    "df_site2image = temp.set_index('site_name')\n",
+    "df_image2site = temp.set_index('image_name')\n",
+    "df_site2image.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not PLANET_ID:\n",
+    "    values = PLANET_ID = df_site2image.loc[SITE_NAME].tolist()\n",
+    "    PLANET_ID = values[0]\n",
+    "    print(f'There was {len(values)} planet images for this chip')\n",
+    "else:\n",
+    "    values = df_image2site.loc[PLANET_ID].tolist()\n",
+    "    SITE_NAME = values[0]\n",
+    "    print(f'There were {len(values)} chips for this planet_image')\n",
+    "\n",
+    "(SITE_NAME, PLANET_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Crop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = Path(f'data/{PLANET_ID}/')\n",
+    "data_dir.mkdir(exist_ok=True, parents=True)\n",
+    "\n",
+    "cropped_dir = Path(f'planet_images_cropped/{PLANET_ID}/')\n",
+    "cropped_dir.mkdir(exist_ok=True, parents=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = len(PLANET_ID)\n",
+    "planet_images = list(data_dir.glob('*.tif'))\n",
+    "planet_image_path = list(filter(lambda x: x.name[:n] == PLANET_ID, planet_images))[0]\n",
+    "planet_image_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with rasterio.open(planet_image_path) as ds:\n",
+    "    planet_crs = ds.crs\n",
+    "    planet_profile = ds.profile\n",
+    "    \n",
+    "planet_profile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parameters for Cropping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapely.geometry import box\n",
+    "\n",
+    "x_ul, y_ul = 445747,5136195\n",
+    "\n",
+    "size_meters = 6_000\n",
+    "\n",
+    "geo = [box(x_ul, y_ul, x_ul + size_meters, y_ul - size_meters)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cropping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapely.geometry import box\n",
+    "\n",
+    "with rasterio.open(planet_image_path) as src:\n",
+    "    out_image, out_transform = rasterio.mask.mask(src, geo, crop=True)\n",
+    "    out_meta = src.meta\n",
+    "\n",
+    "out_meta.update({\"driver\": \"GTiff\",\n",
+    "         \"height\": out_image.shape[1],\n",
+    "         \"width\": out_image.shape[2],\n",
+    "         \"transform\": out_transform,\n",
+    "         \"compress\": \"lzw\"})\n",
+    "\n",
+    "with rasterio.open(cropped_dir / f'cropped_{PLANET_ID}.tif', \"w\", **out_meta) as dest:\n",
+    "    dest.write(out_image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copy original data (if you want), say in the event you are reviewing an old extent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if True:\n",
+    "    shutil.copy(str(planet_image_path),\n",
+    "                str(cropped_dir / f'orig_{PLANET_ID}.tif'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make new raster for hand-editing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if True:\n",
+    "    with rasterio.open(cropped_dir / f'cropped_{PLANET_ID}.tif') as ds:\n",
+    "        mask = ~(ds.read_masks(1).astype(bool))\n",
+    "        \n",
+    "    hand_edited = np.zeros(out_image[0,...].shape, dtype='uint8')\n",
+    "    p_he = out_meta.copy()\n",
+    "    p_he['count'] = 1\n",
+    "    p_he['dtype'] = 'uint8'\n",
+    "    p_he['nodata'] = 255\n",
+    "    p_he['compress'] = 'lzw'\n",
+    "    hand_edited[mask] = 255\n",
+    "    with rasterio.open(cropped_dir / f'hand_edited_{PLANET_ID}.tif', \"w\", **p_he) as dest:\n",
+    "        dest.write(hand_edited, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "show(out_image[0,...], transform=out_transform, ax=ax)\n",
+    "#df_chip_utm.boundary.plot(ax=ax)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
We have a planet image (tilted) and a chip area (yellow box). The background is HLS. Want to crop an area of planet image that does not have so much no data. Notebook specifies upper-left corner in UTM and size in meters to crop (should be 6_000) for our generation.

<img width="598" alt="image" src="https://user-images.githubusercontent.com/5975894/193376577-2584a79d-b87c-401d-b945-1936e3bd42f8.png">
